### PR TITLE
feat: support react-native-nitro-modules 0.35 / React Native 0.83

### DIFF
--- a/expo-plugin/ios/withMainAppEntitlementsFile.ts
+++ b/expo-plugin/ios/withMainAppEntitlementsFile.ts
@@ -99,7 +99,7 @@ export const withMainAppEntitlementsFile: ConfigPlugin<ConfigProps> = (
 
         if (group && hasMatchedGroup) {
           mainAppGroupKey = key;
-          mainAppGroupName = groupPath ?? groupName;
+          mainAppGroupName = groupPath ?? groupName ?? null;
           ScreenRecorderLog.log(
             `Found main app group with name: ${searchName}`
           );
@@ -142,7 +142,7 @@ export const withMainAppEntitlementsFile: ConfigPlugin<ConfigProps> = (
             mainAppGroupKey = key;
             const groupName = getNormalizedString(group.name);
             const groupPath = getNormalizedString(group.path);
-            mainAppGroupName = groupPath ?? groupName;
+            mainAppGroupName = groupPath ?? groupName ?? null;
             ScreenRecorderLog.log(
               `Found main app group by AppDelegate: ${group.name || 'unnamed'}`
             );

--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-prettier": "^5.2.3",
     "jest": "^29.7.0",
-    "nitrogen": "0.33.8",
+    "nitrogen": "0.35.9",
     "prettier": "^3.0.3",
     "react": "19.2.0",
     "react-native": "0.83.1",
     "react-native-builder-bob": "^0.40.12",
-    "react-native-nitro-modules": "0.33.8",
+    "react-native-nitro-modules": "0.35.9",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
     "typescript": "^5.8.3"
@@ -118,7 +118,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "^0.33.8"
+    "react-native-nitro-modules": ">=0.35.0 <1.0.0"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
## Problem

On **React Native 0.83 / Expo SDK 55**, apps need `react-native-nitro-modules@0.35.x` (it's the version compiled against fbjni 0.7.0). But the recorder's published builds target the **nitro 0.33 ABI**, and the 0.33 nitrogen output fails to compile against fbjni 0.7.0:

```
fbjni-0.7.0/.../Hybrid.h: static assertion failed: The base of a HybridClass
  must be either another HybridClass or derived from JObject
JHybridNitroScreenRecorderSpec.hpp: error: unknown type name 'jhybriddata' / 'jhybridobject'
  error: use of undeclared identifier 'registerHybrid' / 'javaClassStatic'
> Task :react-native-nitro-screen-recorder:buildCMakeRelWithDebInfo[arm64-v8a] FAILED
```

So `react-native-nitro-screen-recorder` currently can't be built on any RN 0.83 app — there's no published version compatible with nitro 0.35.

## Change

- Bump `nitrogen` + `react-native-nitro-modules` dev deps to **0.35.9** and widen the peer range to `>=0.35.0 <1.0.0`, so the generated nitrogen output targets the 0.35 ABI (the generated `JHybridNitroScreenRecorderSpec` now derives from `JHybridObject`, satisfying the fbjni assertion).
- Fix a `TS2322` in `expo-plugin/ios/withMainAppEntitlementsFile.ts` that otherwise breaks `build:plugin`: `getNormalizedString()` returns `string | undefined`, but `mainAppGroupName` is `string | null` — coalesce to `null`.

## Verification

Built this against a real RN 0.83.2 / Expo 55 app (nitro-modules 0.35.9):

- `yarn nitrogen` regenerates the HybridObject cleanly; `bob build` + `build:plugin` green.
- Native **EAS Android** builds pass Gradle/CMake on both **arm64-v8a** (preview/Release) and **arm64-v8a + x86_64** (dev/Debug) — the recorder's `buildCMakeRelWithDebInfo` task no longer fails.

Note: this targets the 0.35 ABI, so it drops 0.33 compatibility (a single published build can only target one nitro ABI). Happy to adjust the peer range or versioning (minor/major bump) to whatever you prefer.